### PR TITLE
Improve the rails version management

### DIFF
--- a/hstore_translate.gemspec
+++ b/hstore_translate.gemspec
@@ -14,11 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
   s.rubyforge_project = '[none]'
 
-  if ENV['RAILS_3_1']
-    s.add_dependency 'activerecord', '~> 3.1.0'
-  else
-    s.add_dependency 'activerecord', '~> 3.2.0'
-  end
+  s.add_dependency 'activerecord', '~> 3.1'
 
   s.add_dependency 'activerecord-postgres-hstore', '~> 0.4.0'
 end


### PR DESCRIPTION
- As the next version of Rails is 4, and this gem is compatible with 3.1 and 3.2, we can increase a bit the restriction
