### PR TITLE
Mass-assignment using localized accessors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ I18n.locale = :he
 post.title # => אתר זה טוב
 ```
 
-You also have locale-specific convenience methods:
+You also have locale-specific convenience methods from [easy_globalize3_accessors](https://github.com/paneq/easy_globalize3_accessors):
 
 ```ruby
 I18n.locale = :en

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -90,8 +90,14 @@ class TranslatesTest < Test::Unit::TestCase
     assert_raise(NoMethodError) { Post.new.other_fr }
   end
 
-  def test_persists_translations
+  def test_persists_translations_assigned_as_hash
     p = Post.create!(:title_translations => { "en" => "English Title", "fr" => "Titre français" })
+    p.reload
+    assert_equal({"en" => "English Title", "fr" => "Titre français"}, p.title_translations)
+  end
+
+  def test_persists_translations_assigned_to_localized_accessors
+    p = Post.create!(:title_en => "English Title", :title_fr => "Titre français")
     p.reload
     assert_equal({"en" => "English Title", "fr" => "Titre français"}, p.title_translations)
   end


### PR DESCRIPTION
``` ruby
Post.update_attributes(:title_en => 'updated title')
```

Fixes issue #6.
