### PR TITLE
made dependent on rails 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source "http://rubygems.org"
 
-if ENV["EDGE_RAILS"]
-  gem 'pg'
-  gem 'rails', :git => 'git://github.com/rails/rails'
-else
-  gemspec
-end
+gemspec

--- a/hstore_translate.gemspec
+++ b/hstore_translate.gemspec
@@ -15,18 +15,8 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
   s.rubyforge_project = '[none]'
 
-  if ENV['RAILS_3_1']
-    s.add_dependency 'activerecord', '~> 3.1.0'
-  elsif ENV['RAILS_3_2']
-    s.add_dependency 'activerecord', '~> 3.2.0'
-  elsif ENV['RAILS_4']
-    s.add_dependency 'activerecord', '4.0.0.rc2'
-  else
-    s.add_dependency 'activerecord', '>= 3.1.0'
-  end
-
+  s.add_dependency 'activerecord', '~> 4.0.0'
   s.add_dependency 'pg'
-  s.add_dependency 'activerecord-postgres-hstore', '~> 0.7.0'
 
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
With the new release of rails 4 the dependencies of hstore_translate can be greatly simplified if the requirements are bumped to ActiveRecord 4.0.0 or higher. Without this change bundler pulls in 'activerecord-postgres-hstore' when using hstore translate with Rails 4. Is there an interest in merging this?
