### PR TITLE
Find records with specific translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ post.title # => This database rocks!
 post.title_he # => אתר זה טוב
 ```
 
+To find records using translations without constructing hstore queries by hand:
+
+```ruby
+Post.with_title_translation("This database rocks!") # => #<ActiveRecord::Relation ...>
+Post.with_title_translation("אתר זה טוב", :he) # => #<ActiveRecord::Relation ...>
+```
+
 In order to make this work, you'll need to define an hstore column for each of
 your translated attributes, using the suffix "_translations":
 

--- a/lib/hstore_translate/translates.rb
+++ b/lib/hstore_translate/translates.rb
@@ -17,8 +17,9 @@ module HstoreTranslate
           write_hstore_translation(attr_name, value)
         end
         
-        define_singleton_method "find_by_#{attr_name}" do |value|
-          find_hstore_translation(attr_name, value)
+        define_singleton_method "with_#{attr_name}_translation" do |value, locale = I18n.locale|
+          quoted_translation_store = connection.quote_column_name("#{attr_name}_translations")
+          where("#{quoted_translation_store} @> hstore(:locale, :value)", locale: locale, value: value)
         end
       end
 
@@ -96,11 +97,6 @@ module HstoreTranslate
 
         [translated_attr_name, locale, assigning]
       end
-    end
-    
-    def find_hstore_translation(attr_name, value, locale = I18n.locale)
-      quoted_translation_store = connection.quote_column_name("#{attr_name}_translations")
-      where("#{quoted_translation_store} @> hstore(:locale, :value)", locale: locale, value: value).first
     end
   end
 end

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -113,10 +113,10 @@ class TranslatesTest < HstoreTranslate::Test
     assert_equal({"en" => "English Title", "fr" => "Titre français"}, p.title_translations)
   end
   
-  def test_adds_a_find_by_finder
+  def test_with_translation_relation
     p = Post.create!(:title_translations => { "en" => "Alice in Wonderland", "fr" => "Alice au pays des merveilles" })
     I18n.with_locale(:en) do
-      assert_equal(p.title_en, Post.find_by_title("Alice in Wonderland").try(:title))
+      assert_equal p.title_en, Post.with_title_translation("Alice in Wonderland").first.try(:title)
     end
   end
 end


### PR DESCRIPTION
In response to https://github.com/robworley/hstore_translate/pull/19. To find records using translations without constructing hstore queries by hand:

``` ruby
Post.with_title_translation("This database rocks!") # => #<ActiveRecord::Relation ...>
Post.with_title_translation("אתר זה טוב", :he) # => #<ActiveRecord::Relation ...>
```

This approach makes no assumptions about cardinality and should play nicely across all supported ActiveRecord versions. We can call `#first`, `#first!`, `#any?`, `#count` etc. and chain with other relations.
