### PR TITLE
Add some global validations (presence, length and format).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # hstore_translate
 
-Rails I18n library for ActiveRecord model/data translation using PostgreSQL's 
-hstore datatype. It provides an interface inspired by 
-[Globalize3](https://github.com/svenfuchs/globalize3) but removes the need to 
+Rails I18n library for ActiveRecord model/data translation using PostgreSQL's
+hstore datatype. It provides an interface inspired by
+[Globalize3](https://github.com/svenfuchs/globalize3) but removes the need to
 maintain separate translation tables.
 
 [![Build Status](https://api.travis-ci.org/robworley/hstore_translate.png)](https://travis-ci.org/robworley/hstore_translate)
@@ -123,4 +123,15 @@ I18n.locale = :en
 post.title # => This database rocks!
 post.disable_fallback
 post.title_nl # => nil
+```
+
+## Model validations
+
+It's possible to use some global validation features.
+
+```
+validates_hstore_translate :title, presence: true
+validates_hstore_translate :title, length: { minimum: 8 }
+validates_hstore_translate :title, length: { maximum: 200 }
+validates_hstore_translate :title, format: { with: /regexp/ }
 ```

--- a/lib/hstore_translate.rb
+++ b/lib/hstore_translate.rb
@@ -1,6 +1,7 @@
 require 'active_record'
 require 'active_record/connection_adapters/postgresql_adapter'
 require 'hstore_translate/translates'
+require 'hstore_translate/active_record_extensions'
 
 module HstoreTranslate
   def self.native_hstore?

--- a/lib/hstore_translate/active_record_extensions.rb
+++ b/lib/hstore_translate/active_record_extensions.rb
@@ -1,0 +1,49 @@
+module HstoreTranslate
+  module ActiveRecordExtensions
+
+    module ClassMethods
+
+      def validates_hstore_translate(*attributes)
+        options = {
+          presence: false,
+          length: { allow_blank: false },
+          format: {}
+        }.merge(attributes.extract_options!)
+
+        options.assert_valid_keys([:presence, :length, :format])
+
+        attributes.each do |attribute|
+          I18n.available_locales.each do |locale|
+            if options[:presence]
+              module_eval do
+                validates "#{attribute}_#{locale}", presence: true
+              end
+            end
+
+            if options[:length]
+              module_eval do
+                if options[:length][:minimum]
+                  validates "#{attribute}_#{locale}", length: { minimum: options[:length][:minimum] },
+                    allow_blank: options[:length][:allow_blank]
+                end
+                if options[:length][:maximum]
+                  validates "#{attribute}_#{locale}", length: { maximum: options[:length][:maximum] },
+                    allow_blank: options[:length][:allow_blank]
+                end
+              end
+            end
+
+            if options[:format]
+              module_eval do
+                validates "#{attribute}_#{locale}", format: { with: options[:format][:with] }
+              end
+            end
+          end
+        end
+      end
+
+    end
+  end
+end
+
+ActiveRecord::Base.extend HstoreTranslate::ActiveRecordExtensions::ClassMethods

--- a/test/active_record_extensions_test.rb
+++ b/test/active_record_extensions_test.rb
@@ -1,0 +1,62 @@
+# -*- encoding : utf-8 -*-
+require 'test_helper'
+
+class ActiveRecordExtensionsTest < HstoreTranslate::Test
+
+  def setup
+    I18n.available_locales = [:en, :fr]
+  end
+
+  def teardown
+    Post.reset_callbacks(:validate)
+  end
+
+  def test_validates_presence
+    Post.validates_hstore_translate(:title, { presence: true })
+    I18n.with_locale(:fr) do
+      p = Post.new(title_translations: { "en" => "English Title", "fr" => "" })
+      assert p.invalid?
+      p.title_fr = 'Titre Français'
+      assert p.valid?
+    end
+  end
+
+  def test_validates_length_minimum
+    Post.validates_hstore_translate(:title, { length: { minimum: 6 } })
+    I18n.with_locale(:fr) do
+      p = Post.new(title_translations: { "en" => "Long Title", "fr" => "Court" })
+      assert p.invalid?
+      p.title_fr = 'Long Titre'
+      assert p.valid?
+    end
+  end
+
+  def test_validates_length_allow_blank
+    Post.validates_hstore_translate(:title, { length: { minimum: 6, allow_blank: true } })
+    I18n.with_locale(:fr) do
+      p = Post.new(title_translations: { "en" => "Long Title", "fr" => "" })
+      assert p.valid?
+    end
+  end
+
+  def test_validates_length_maximum
+    Post.validates_hstore_translate(:title, { length: { maximum: 6 } })
+    I18n.with_locale(:fr) do
+      p = Post.new(title_translations: { "en" => "Title", "fr" => "Long Titre" })
+      assert p.invalid?
+      p.title_fr = 'Titre'
+      assert p.valid?
+    end
+  end
+
+  def test_validates_format
+    Post.validates_hstore_translate(:title, { format: { with: /\A\w+\z/ } })
+    I18n.with_locale(:fr) do
+      p = Post.new(title_translations: { "en" => "Title", "fr" => "Titre?" })
+      assert p.invalid?
+      p.title_fr = 'Titre'
+      assert p.valid?
+    end
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'hstore_translate'
 
 require 'database_cleaner'
 DatabaseCleaner.strategy = :transaction
+I18n.enforce_available_locales = false
 
 class Post < ActiveRecord::Base
   translates :title


### PR DESCRIPTION
Hello Rob,

What do you think about adding some global validations on translated attributes?
It's just a beginning with `:presence`, `:length` and `:format` but I plan to support more validations.

Maybe we could export that logic into another gem then?
