### PR TITLE
fixed guard regex to support locales with more than two letters 

### DIFF
--- a/lib/hstore_translate/translates.rb
+++ b/lib/hstore_translate/translates.rb
@@ -107,7 +107,7 @@ module HstoreTranslate
       # Returns the attribute name Symbol, locale Symbol, and a Boolean
       # indicating whether or not the caller is attempting to assign a value.
       def parse_translated_attribute_accessor(method_name)
-        return unless method_name =~ /\A([a-z_]+)_([a-z]{2})(=?)\z/
+        return unless method_name =~ /\A([a-z_]+)_([a-z]{2}|[a-z]{2}-[A-Z]{2,3})(=?)\z/
 
         translated_attr_name = $1.to_sym
         return unless translated_attrs.include?(translated_attr_name)


### PR DESCRIPTION
This is a small fix that allows translations for locales that have more than two letters (e.g.: zh-TW, it-CH).
