### PR TITLE
allow to search for alternative values of translated attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To find records using translations without constructing hstore queries by hand:
 ```ruby
 Post.with_title_translation("This database rocks!") # => #<ActiveRecord::Relation ...>
 Post.with_title_translation("אתר זה טוב", :he) # => #<ActiveRecord::Relation ...>
+Post.with_title_translation(['first', 'second']) # => #<ActiveRecord::Relation ...>
 ```
 
 In order to make this work, you'll need to define an hstore column for each of

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -142,6 +142,13 @@ class TranslatesTest < HstoreTranslate::Test
     end
   end
 
+  def test_with_translation_relation_given_array
+    p = Post.create!(:title_translations => { "en" => "Alice in Wonderland", "fr" => "Alice au pays des merveilles" })
+    I18n.with_locale(:en) do
+      assert_equal p.title_en, Post.with_title_translation(["Alice in Wonderland", "Hunting of the Snark"]).first.try(:title)
+    end
+  end
+
   def test_class_method_translates?
     assert_equal true, Post.translates?
   end


### PR DESCRIPTION
This way, we can search for multiple records within a locale at once.
