### PR TITLE
Add order_by feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ Post.with_title_translation("This database rocks!") # => #<ActiveRecord::Relatio
 Post.with_title_translation("אתר זה טוב", :he) # => #<ActiveRecord::Relation ...>
 ```
 
+To order records using translations without constructing hstore queries by hand:
+
+```ruby
+Post.order_by_title_translation # will order by :asc in current locale
+Post.order_by_title_translation(:asc)
+Post.order_by_title_translation(:desc, :he)
+```
+
 In order to make this work, you'll need to define an hstore column for each of
 your translated attributes, using the suffix "_translations":
 

--- a/lib/hstore_translate/translates.rb
+++ b/lib/hstore_translate/translates.rb
@@ -22,6 +22,11 @@ module HstoreTranslate
           quoted_translation_store = connection.quote_column_name("#{attr_name}_translations")
           where("#{quoted_translation_store} @> hstore(:locale, :value)", locale: locale, value: value)
         end
+
+        define_singleton_method "order_by_#{attr_name}_translation" do |direction = :asc, locale = I18n.locale|
+          literal = Arel::SqlLiteral.new("#{attr_name}_translations->'#{locale}'")
+          order(literal.send(direction))
+        end
       end
 
       alias_method_chain :respond_to?, :translates

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -142,6 +142,30 @@ class TranslatesTest < HstoreTranslate::Test
     end
   end
 
+  def test_default_order_by_translation_relation
+    Post.create!(:title_translations => { "en" => "Bob in Wonderland" })
+    p = Post.create!(:title_translations => { "en" => "Alice in Wonderland" })
+    I18n.with_locale(:en) do
+      assert_equal p.title_en, Post.order_by_title_translation.first.try(:title)
+    end
+  end
+
+  def test_asc_order_by_translation_relation
+    Post.create!(:title_translations => { "en" => "Bob in Wonderland" })
+    p = Post.create!(:title_translations => { "en" => "Alice in Wonderland" })
+    I18n.with_locale(:en) do
+      assert_equal p.title_en, Post.order_by_title_translation(:asc).first.try(:title)
+    end
+  end
+
+  def test_desc_order_by_translation_relation
+    p = Post.create!(:title_translations => { "en" => "Bob in Wonderland" })
+    Post.create!(:title_translations => { "en" => "Alice in Wonderland" })
+    I18n.with_locale(:en) do
+      assert_equal p.title_en, Post.order_by_title_translation(:desc).first.try(:title)
+    end
+  end
+
   def test_class_method_translates?
     assert_equal true, Post.translates?
   end


### PR DESCRIPTION
Simple shortcut which allows to order by translated column as described in readme.
