### PR TITLE
Travis update - ruby versions and badge url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 rvm:
   - 1.9.3
-  - 2.0.0
+  - 2.0
+  - 2.1
   - rbx
   - jruby-19mode
 gemfile:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ hstore datatype. It provides an interface inspired by
 [Globalize3](https://github.com/svenfuchs/globalize3) but removes the need to
 maintain separate translation tables.
 
-[![Build Status](https://api.travis-ci.org/robworley/hstore_translate.png)](https://travis-ci.org/robworley/hstore_translate)
+[![Build Status](https://api.travis-ci.org/Leadformance/hstore_translate.png)](https://travis-ci.org/Leadformance/hstore_translate)
 [![License](http://img.shields.io/badge/license-mit-brightgreen.svg)](COPYRIGHT)
 [![Code Climate](https://codeclimate.com/github/robworley/hstore_translate.png)](https://codeclimate.com/github/robworley/hstore_translate)
 


### PR DESCRIPTION
Minor updates to test on rubt 2.1 (latest) and 2.0 (latest)

As well as correct links for the badges in the readme
