### PR TITLE
Fix stack exception when calling `translates` multiple times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3
   - rbx
   - jruby-19mode
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 rvm:
   - 1.9.3
-  - 2.0.0
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
   - rbx
   - jruby-19mode
 gemfile:
@@ -8,6 +11,8 @@ gemfile:
   - test/gemfiles/Gemfile.rails-3.2.x
   - test/gemfiles/Gemfile.rails-4.0.x
   - test/gemfiles/Gemfile.rails-4.1.x
+before_install:
+  - gem update bundler
 matrix:
   exclude:
     - rvm: jruby-19mode

--- a/lib/hstore_translate/translates.rb
+++ b/lib/hstore_translate/translates.rb
@@ -8,7 +8,7 @@ module HstoreTranslate
 
       self.translated_attrs ||= []
 
-      if (!self.translated_attrs.empty?)
+      if (self.translated_attrs.empty?)
         alias_method_chain :respond_to?, :translates
         alias_method_chain :method_missing, :translates
       end

--- a/lib/hstore_translate/translates.rb
+++ b/lib/hstore_translate/translates.rb
@@ -3,12 +3,12 @@ module HstoreTranslate
     def translates(*attrs)
       include InstanceMethods
 
-      class_attribute :translated_attrs
-      alias_attribute :translated_attribute_names, :translated_attrs # Improve compatibility with the gem globalize
+      unless self.respond_to?(:translated_attrs)
+        class_attribute :translated_attrs
+        alias_attribute :translated_attribute_names, :translated_attrs # Improve compatibility with the gem globalize
 
-      self.translated_attrs ||= []
+        self.translated_attrs ||= []
 
-      if (self.translated_attrs.empty?)
         alias_method_chain :respond_to?, :translates
         alias_method_chain :method_missing, :translates
       end

--- a/lib/hstore_translate/translates.rb
+++ b/lib/hstore_translate/translates.rb
@@ -5,9 +5,17 @@ module HstoreTranslate
 
       class_attribute :translated_attrs
       alias_attribute :translated_attribute_names, :translated_attrs # Improve compatibility with the gem globalize
-      self.translated_attrs = attrs
+
+      self.translated_attrs ||= []
+
+      if (!self.translated_attrs.empty?)
+        alias_method_chain :respond_to?, :translates
+        alias_method_chain :method_missing, :translates
+      end
 
       attrs.each do |attr_name|
+        self.translated_attrs << attr_name
+
         serialize "#{attr_name}_translations", ActiveRecord::Coders::Hstore unless HstoreTranslate::native_hstore?
 
         define_method attr_name do
@@ -23,9 +31,6 @@ module HstoreTranslate
           where("#{quoted_translation_store} @> hstore(:locale, :value)", locale: locale, value: value)
         end
       end
-
-      alias_method_chain :respond_to?, :translates
-      alias_method_chain :method_missing, :translates
     end
 
     # Improve compatibility with the gem globalize

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'hstore_translate'
-
 require 'database_cleaner'
+
 DatabaseCleaner.strategy = :transaction
 
 MiniTest::Test = MiniTest::Unit::TestCase unless MiniTest.const_defined?(:Test) # Rails 4.0.x
@@ -10,11 +10,17 @@ class Post < ActiveRecord::Base
   translates :title
 end
 
+class Comment < ActiveRecord::Base
+  translates :name
+  translates :body
+end
+
 class HstoreTranslate::Test < Minitest::Test
   class << self
     def prepare_database
       create_database
-      create_table
+      create_posts_table
+      create_comments_table
     end
 
     private
@@ -51,10 +57,18 @@ class HstoreTranslate::Test < Minitest::Test
       end
     end
 
-    def create_table
+    def create_posts_table
       connection = establish_connection(db_config)
       connection.create_table(:posts, :force => true) do |t|
         t.column :title_translations, 'hstore'
+      end
+    end
+
+    def create_comments_table
+      connection = establish_connection(db_config)
+      connection.create_table(:comments, :force => true) do |t|
+        t.column :name_translations, 'hstore'
+        t.column :body_translations, 'hstore'
       end
     end
   end

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -144,5 +144,14 @@ class TranslatesTest < HstoreTranslate::Test
 
   def test_class_method_translates?
     assert_equal true, Post.translates?
+    assert_equal true, Comment.translates?
+  end
+
+  def test_model_with_double_translates_definition
+    I18n.with_locale(:en) do
+      c = Comment.new(:name => "Wadus", :body => "LOL nice post my friend")
+      assert_equal("Wadus", c.name_translations['en'])
+      assert_equal("LOL nice post my friend", c.body_translations['en'])
+    end
   end
 end


### PR DESCRIPTION
In a project I'm working on, I have this models:

``` ruby
class Object < ActiveRecord::Base
  translates :name
end
```

``` ruby
class Table < Object
  translates :wadus
end
```

As you can see, I'm using Single Table Inheritance to store different kind of Objects in the same table. As I want to translate both fields, I have to call `translates` method two times (I could call it only once in `Object` class, but `:wadus` field it's supposed to be only un `Table` model).

This causes an `alias_method` loop that ends in an `Stack level too deep` exception. To fix it, I've create a patch that verifies if the model already has translated attributes, in which case avoids creating the aliases, so this loop never happens.

And thanks for your work in this gem, it's awesome!
