### PR TITLE
Rails 5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 pkg/*
 test/coverage
+.idea/

--- a/lib/hstore_translate/translates.rb
+++ b/lib/hstore_translate/translates.rb
@@ -28,9 +28,11 @@ module HstoreTranslate
 
       alias_method :respond_to_without_translates?, :respond_to?
       alias_method :respond_to?, :respond_to_with_translates?
+      protected :respond_to_with_translates?
 
       alias_method :method_missing_without_translates, :method_missing
       alias_method :method_missing, :method_missing_with_translates
+      protected :method_missing_with_translates
     end
 
     # Improve compatibility with the gem globalize

--- a/lib/hstore_translate/translates.rb
+++ b/lib/hstore_translate/translates.rb
@@ -26,8 +26,11 @@ module HstoreTranslate
         end
       end
 
-      alias_method_chain :respond_to?, :translates
-      alias_method_chain :method_missing, :translates
+      alias_method :respond_to_without_translates?, :respond_to?
+      alias_method :respond_to?, :respond_to_with_translates?
+
+      alias_method :method_missing_without_translates, :method_missing
+      alias_method :method_missing, :method_missing_with_translates
     end
 
     # Improve compatibility with the gem globalize


### PR DESCRIPTION
replaced `alias_method_chain` calls with `alias_method` so they don't raise deprecation warnings in Rails 5
